### PR TITLE
Enforce that HubSpot wants credentials in request body

### DIFF
--- a/lib/omniauth/strategies/hubspot.rb
+++ b/lib/omniauth/strategies/hubspot.rb
@@ -12,7 +12,8 @@ module OmniAuth
       option :client_options, {
         site:           'https://api.hubapi.com',
         authorize_url:  'https://app.hubspot.com/oauth/authorize',
-        token_url:      '/oauth/v1/token'
+        token_url:      '/oauth/v1/token',
+        auth_scheme:    :request_body
       }
 
       option :auth_token_params, {


### PR DESCRIPTION
The `oauth2` gem has published a new major version with a breaking change that impacts this strategy: https://github.com/oauth-xx/oauth2/pull/312

Now `oauth2` will default to sending client_id / secret via Basic Auth headers instead of the request body. Hubspot is expecting the client_id in the body and we started receiving these errors are attempting to upgrade:

```
Authentication failure! invalid_credentials: OAuth2::Error, {“status”:“BAD_CLIENT_ID”,“message”:“missing or unknown client id”,“correlationId”:“REDACTED”}
```

This change sets the `oauth2` client option for `auth_scheme` to `request_body` (which was the default before the v2 changes)